### PR TITLE
Exporting *.d.ts files

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -26,3 +26,5 @@ program
     .option('-t, --type <char>')
     .action(generate)
     .parse()
+
+export {CardEditor} from './domain/cardEditor.js'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -50,9 +50,9 @@
     // "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from 'node_modules'. Only applicable with 'allowJs'. */
 
     /* Emit */
-    // "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
-    // "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
-    // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
+    "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
+    "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
+    "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
     // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
     // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
     // "noEmit": true,                                   /* Disable emitting files from a compilation. */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -52,7 +52,7 @@
     /* Emit */
     "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
     "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
-    "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
+    // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
     // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
     // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
     // "noEmit": true,                                   /* Disable emitting files from a compilation. */


### PR DESCRIPTION
Exporting *.d.ts will allow us to use this as an actual dependency for another project, in case we don't want to use the CLI