### PR TITLE
Separating exports from the CLI

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,12 @@
 
 All changes to the project will be documented here.
 
+## [Unreleased]
+
+### Added
+
+- Exporting utility functions
+
 ## [v1.1.0] - 2024-11-16
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "description": "Library of Ruina Card Generator",
   "main": "./dist/index.js",
   "bin": {
-    "lor-card": "dist/index.js"
+    "lor-card": "dist/infrastructure/cli.js"
   },
   "files": [
     "./assets",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,50 +1,6 @@
-#!/usr/bin/env node
+// Domain
+export {CardDefinition} from './domain/cardDefinition.js'
+export {hexToRgb} from './domain/utils/utils.js'
 
-import { program } from "commander";
-import { CardEditor } from "./infrastructure/cardEditor.js";
-import { ErrorMessage } from "./domain/utils/errorHandler.js";
-import { Colors } from "./domain/color.js";
-import { Filters } from "./domain/filter.js";
-import { userInputSchema } from "./domain/userInput.js";
-
-const generate = async (option: Record<string, string|undefined>) => {
-    const {data, error} = userInputSchema.safeParse(option)
-
-    if(error){
-        console.table(error.issues)
-        throw new ErrorMessage('parser', 'The input provided is invalid, please review the table above!')
-    }
-
-    const {attacks, cost, name, range, type, image} = data
-    const cardDefinition = {
-        color: Colors[type],
-        filter: Filters[type],
-        image,
-        name,
-        cost: cost,
-        attack: range,
-        attacks: attacks
-    }
-    
-    const cardEditor = new CardEditor(cardDefinition)
-    
-    cardEditor.load()
-    
-    await cardEditor.card.create()
-    await cardEditor.card.save()
-}
-
-program
-    .name('lor-card')
-    .description('CLI to generate a Card that looks like from Library of Ruina')
-    .version('1.1.0')
-    .option('-a, --attacks <char>')
-    .option('-c, --cost <char>')
-    .option('-i, --image <char>')
-    .option('-n, --name <char>')
-    .option('-r, --range <char>')
-    .option('-t, --type <char>')
-    .action(generate)
-    .parse()
-
+// Infrastructure
 export {CardEditor} from './infrastructure/cardEditor.js'

--- a/src/infrastructure/cli.ts
+++ b/src/infrastructure/cli.ts
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+
+import { program } from "commander";
+import { CardEditor } from "./cardEditor.js";
+import { ErrorMessage } from "../domain/utils/errorHandler.js";
+import { Colors } from "../domain/color.js";
+import { Filters } from "../domain/filter.js";
+import { userInputSchema } from "../domain/userInput.js";
+
+const generate = async (option: Record<string, string|undefined>) => {
+    const {data, error} = userInputSchema.safeParse(option)
+
+    if(error){
+        console.table(error.issues)
+        throw new ErrorMessage('parser', 'The input provided is invalid, please review the table above!')
+    }
+
+    const {attacks, cost, name, range, type, image} = data
+    const cardDefinition = {
+        color: Colors[type],
+        filter: Filters[type],
+        image,
+        name,
+        cost: cost,
+        attack: range,
+        attacks: attacks
+    }
+    
+    const cardEditor = new CardEditor(cardDefinition)
+    
+    cardEditor.load()
+    
+    await cardEditor.card.create()
+    await cardEditor.card.save()
+}
+
+program
+    .name('lor-card')
+    .description('CLI to generate a Card that looks like from Library of Ruina')
+    .version('1.1.0')
+    .option('-a, --attacks <char>')
+    .option('-c, --cost <char>')
+    .option('-i, --image <char>')
+    .option('-n, --name <char>')
+    .option('-r, --range <char>')
+    .option('-t, --type <char>')
+    .action(generate)
+    .parse()


### PR DESCRIPTION
We currently have the CLI and index exports on the same file, this PR moves them to an appropriate file, alongside exporting a color helper.